### PR TITLE
change element-id and adjust css

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.572</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction/floatingBox.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction/floatingBox.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <j:set var="result" value="${it.lastBuild.result.toString()}"/>
   <script>
-    Element.setStyle($('main-table'), {
+    Element.setStyle($('side-panel'), {
       <j:choose>
         <j:when test='${result.equals("UNSTABLE")}'>
           'background-image': 'url(${rootURL}/plugin/emotional-jenkins-plugin/images/sad-jenkins.png)'
@@ -13,6 +13,8 @@
           'background-image': 'url(${rootURL}/plugin/emotional-jenkins-plugin/images/jenkins.png)'
         </j:otherwise>
       </j:choose>
+      ,'background-repeat' : 'no-repeat'
+      ,'background-size' : '55%'
     });
   </script>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction/summary.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <j:set var="result" value="${it.result.toString()}"/>
   <script>
-    Element.setStyle($('main-table'), {
+    Element.setStyle($('side-panel'), {
       <j:choose>
         <j:when test='${result.equals("UNSTABLE")}'>
           'background-image': 'url(${rootURL}/plugin/emotional-jenkins-plugin/images/sad-jenkins.png)'
@@ -13,6 +13,8 @@
           'background-image': 'url(${rootURL}/plugin/emotional-jenkins-plugin/images/jenkins.png)'
         </j:otherwise>
       </j:choose>
+      ,'background-repeat' : 'no-repeat'
+      ,'background-size' : '55%'
     });
   </script>
 </j:jelly>


### PR DESCRIPTION
'#main-table' has been removed from Jenkins since version 1.572.
http://jenkins-ci.org/changelog#v1.572
https://github.com/jenkinsci/jenkins/pull/1310

Current version Jenkins has '#side-panel' that is nice place for emotional-jenkins images.
