### PR TITLE
Updated to use SimpleBuildStep and thus be usable from a Workflow build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+work

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.572</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.580.1</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction.java
@@ -7,8 +7,6 @@ public final class EmotionalJenkinsAction implements ProminentProjectAction {
 
     private Result result;
 
-    public EmotionalJenkinsAction() {}
-
     public EmotionalJenkinsAction(Result result) {
         this.result = result;
     }

--- a/src/main/java/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction.java
+++ b/src/main/java/org/jenkinsci/plugins/emotional_jenkins/EmotionalJenkinsAction.java
@@ -7,6 +7,9 @@ public final class EmotionalJenkinsAction implements ProminentProjectAction {
 
     private Result result;
 
+    @Deprecated
+    public EmotionalJenkinsAction() {}
+
     public EmotionalJenkinsAction(Result result) {
         this.result = result;
     }


### PR DESCRIPTION
``` groovy
node {
  catchError {
    if (Integer.parseInt(env.BUILD_NUMBER) % 3 == 0) {
      error 'oops'
    }
  }
  step([$class: 'EmotionalJenkinsPublisher'])
}
```

Currently kind of useless since in 1.580.1 the butler sidepanel is no longer displayed, but that could be fixed independently I suppose. Functionality confirmed via inspection of `EmotionalJenkinsAction.result` via `Job.allActions` and `Run.allActions`.

@reviewbybees
